### PR TITLE
Fix professional experience typos

### DIFF
--- a/src/app/components/resume/resume.component.html
+++ b/src/app/components/resume/resume.component.html
@@ -4,7 +4,7 @@
   <hr/>
   <memija-resume-key-points></memija-resume-key-points>
   <hr/>
-  {{ professionalExperince }}
+  {{ professionalExperience }}
   <hr/>
   <memija-resume-professional-experience></memija-resume-professional-experience>
   <hr/>

--- a/src/app/components/resume/resume.component.ts
+++ b/src/app/components/resume/resume.component.ts
@@ -17,13 +17,13 @@ export class ResumeComponent implements OnInit {
   public keyPoints!: string;
 
   /**
-   * Professional experince.
+   * Professional experience.
    */
-  public professionalExperince!: string;
+  public professionalExperience!: string;
 
   ngOnInit() {
     this.education = language.resume.headers.education.toUpperCase();
     this.keyPoints = language.resume.headers.keyPoints.toUpperCase();
-    this.professionalExperince = language.resume.headers.professionalExperince.toUpperCase();
+    this.professionalExperience = language.resume.headers.professionalExperience.toUpperCase();
   }
 }

--- a/src/app/localization/languages/english-language.ts
+++ b/src/app/localization/languages/english-language.ts
@@ -42,7 +42,7 @@ export const englishLanguage = {
     headers: {
       education: 'Education',
       keyPoints: 'Key points',
-      professionalExperince: 'Professional experince'
+      professionalExperience: 'Professional experience'
     },
     keyPoints: [
       'Team building, hiring, mentoring, client engagement, cross-functional collaboration',

--- a/src/app/localization/languages/german-language.ts
+++ b/src/app/localization/languages/german-language.ts
@@ -42,7 +42,7 @@ export const germanLanguage = {
     headers: {
       education: 'Ausbildung',
       keyPoints: 'Wichtige punkte',
-      professionalExperince: 'Berufserfahrung'
+      professionalExperience: 'Berufserfahrung'
     },
     keyPoints: [
       'Teambildung, Einstellung, Mentoring, Kundenbindung, funktionsübergreifende Zusammenarbeit',

--- a/src/app/models/resume/ProfessionalExperience.ts
+++ b/src/app/models/resume/ProfessionalExperience.ts
@@ -3,7 +3,7 @@
  */
 export class ProfessionalExperience {
   /**
-   * Start and end of professinal experince.
+   * Start and end of professional experience.
    */
   fromTo!: string;
 


### PR DESCRIPTION
This submission fixes multiple spelling errors where "experience" was misspelled as "experince". The changes are safe as they uniformly rename the property and related text across localization, model, and component files.

---
*PR created automatically by Jules for task [927695769598920442](https://jules.google.com/task/927695769598920442) started by @Memija*