### PR TITLE
fix: fix spelling errors across the project

### DIFF
--- a/server.log
+++ b/server.log
@@ -1,0 +1,3 @@
+
+> memija@1.0.0 start
+> node server.js

--- a/server.log
+++ b/server.log
@@ -1,3 +1,0 @@
-
-> memija@1.0.0 start
-> node server.js

--- a/src/app/components/resume/download/download.component.ts
+++ b/src/app/components/resume/download/download.component.ts
@@ -27,6 +27,6 @@ export class ResumeDownloadComponent implements OnInit {
   ngOnInit() {
     this.fileName = language.resume.download.fileName;
     this.title = language.resume.download.title;
-    this.url = configuration.language.activeLanguage === languages.german ? '../../../../assets/files/resume/deutch/Resume.pdf' : '../../../../assets/files/resume/english/Resume.pdf';
+    this.url = configuration.language.activeLanguage === languages.german ? '../../../../assets/files/resume/deutsche/Resume.pdf' : '../../../../assets/files/resume/english/Resume.pdf';
   }
 }

--- a/src/app/localization/languages/language.utility.ts
+++ b/src/app/localization/languages/language.utility.ts
@@ -6,8 +6,8 @@ import { languages } from './languages';
  export class LanguageUtility {
 
   /**
-   * Get active languge value.
-   * @returns Active languge value.
+   * Get active language value.
+   * @returns Active language value.
    */
   static getActiveLanguageValue(): string {
     return this.getActiveLanguage();
@@ -33,7 +33,7 @@ import { languages } from './languages';
     const localStorageMarker = 'language';
     if (localStorage[localStorageMarker]) {
       return localStorage[localStorageMarker];
-    } else if (navigator.language === languages.germanStandards.deutchland ||
+    } else if (navigator.language === languages.germanStandards.deutschland ||
                navigator.language === languages.germanStandards.schweiz ||
                navigator.language === languages.germanStandards.österreich ||
                navigator.language === languages.germanStandards.luxemburg ||

--- a/src/app/localization/languages/languages.ts
+++ b/src/app/localization/languages/languages.ts
@@ -2,7 +2,7 @@ export const languages = {
   german: 'DE',
   english: 'EN',
   germanStandards: {
-    deutchland: 'de',
+    deutschland: 'de',
     schweiz: 'de-CH',
     österreich: 'de-AT',
     luxemburg: 'de-LU',

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -18,7 +18,7 @@
  */
 
 /** IE9, IE10 and IE11 requires all of the following polyfills. **/
-/** IE10 and IE11 requires the following for the Reflect API (Application Programing Interface). */
+/** IE10 and IE11 requires the following for the Reflect API (Application Programming Interface). */
 /**
  * If the application will be indexed by Google Search, the following is required.
  * Googlebot uses a renderer based on Chrome 41.


### PR DESCRIPTION
- Identified and fixed several spelling errors across the project using `cspell` output.
- Specifically fixed variables and properties like `languge` and `deutchland`.
- Corrected the spelling of `Programing` to `Programming` in polyfills.
- Ensured the resume download component properly points to the correct asset folder, and renamed the folder from `deutch` to `deutsche` for the German resume to ensure downloading functionality works correctly.
- Addressed code review feedback by resolving the broken resume download feature resulting from the original code change path fix, and making sure temporary artifacts were removed.

---
*PR created automatically by Jules for task [15323271499574898456](https://jules.google.com/task/15323271499574898456) started by @Memija*